### PR TITLE
[cache] When retrieving from cache, let the user know we got a match

### DIFF
--- a/src/git-got
+++ b/src/git-got
@@ -121,8 +121,13 @@ class Remote(object):
       return False
 
     logging.debug('retrieving file from cache')
+    size = os.path.getsize(path)
+
     try:
+      print_transfer_string(0, size, filename, 'Downloading (cached)')
       shutil.copyfile(path, filename)
+      print_transfer_string(size, size, filename, 'Downloading (cached)')
+      sys.stdout.write("\n")
       return True
     except Exception, e:
       logging.exception('Failed retrieving from cache', e)


### PR DESCRIPTION
If the file is available on the local cache, then print a message
for downloading to inform the user that the download is happening.